### PR TITLE
Add more efficient image data access

### DIFF
--- a/rotpy/image.pxd
+++ b/rotpy/image.pxd
@@ -31,6 +31,8 @@ cdef class Image:
     cpdef get_buffer_size(self)
     cpdef get_image_data_size(self)
     cpdef get_image_data(self)
+    cpdef get_image_data_memoryview(self)
+    cpdef copy_image_data(self, unsigned char[:] buffer)
     cpdef get_data_max(self)
     cpdef get_data_min(self)
     cpdef get_image_id(self)


### PR DESCRIPTION
Fixes #1.

With these changes:

```py
from timeit import timeit
from rotpy.image import Image

empty_img = Image.create_empty()
full_image = Image.create_image(640, 480, 0, 0, 'Mono16')
buffer = bytearray(b'\0') * full_image.get_image_data_size()


setup = '''
from rotpy.image import Image
from __main__ import empty_img, full_image, buffer
'''
stmt_empty = '''
image = Image.create_empty()
'''
stmt_full = '''
image = Image.create_image(640, 480, 0, 0, 'Mono16')
'''
stmt_get_data = '''
data = full_image.get_image_data()
'''
stmt_get_data_mview = '''
data = full_image.get_image_data_memoryview()
'''
stmt_copy_data_mview = '''
full_image.copy_image_data(buffer)
'''

print(f'Empty image: {timeit(stmt=stmt_empty, setup=setup, number=1000):f} sec / 1000')
print(f'Full image: {timeit(stmt=stmt_full, setup=setup, number=1000):f} sec / 1000')
print(f'Get data: {timeit(stmt=stmt_get_data, setup=setup, number=1000):f} sec / 1000')
print(f'Get data memoryview: {timeit(stmt=stmt_get_data_mview, setup=setup, number=1000):f} sec / 1000')
print(f'Copy to buffer: {timeit(stmt=stmt_copy_data_mview, setup=setup, number=1000):f} sec / 1000')
```

prints:

```
Empty image: 0.001878 sec / 1000
Full image: 0.002359 sec / 1000
Get data: 0.045437 sec / 1000
Get data memoryview: 0.001034 sec / 1000
Copy to buffer: 0.026611 sec / 1000
```